### PR TITLE
Normative: Mimic a prototype chain for static private fields

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49,7 +49,7 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
 <emu-clause id=sec-algorithms>
   <h1>Algorithms</h1>
 
-<emu-clause id="initialize-class-elements" aoid="InitializeClassElements">
+<emu-clause id="sec-initialize-class-elements" aoid="InitializeClassElements">
   <h1>InitializeClassElements(_F_, _proto_)</h1>
 
   <emu-alg>
@@ -72,18 +72,65 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
   <emu-note type=editor>Value properties are added before initializers so that all methods are visible from all initializers</emu-note>
 </emu-clause>
 
-<emu-clause id="copy-immutable-private-elements" aoid=CopyImmutablePrivateElements>
-  <h1>CopyImmutablePrivateElements ( _F_, _constructorProto_ )</h1>
+<emu-clause id=sec-private-forwarding-descriptor aoid=PrivateForwardingDescriptor>
+  <h1>PrivateForwardingDescriptor ( _descriptor_ )</h1>
+  <emu-alg>
+    1. Let _valueBox_ be a new Record { [[Value]]: ~empty~ }.
+    1. Let _setter_ be a new built-in function object as defined in Private Forwarding Setter Functions (<emu-xref href="#sec-private-forwarding-setter-functions"></emu-xref>).
+    1. Set _setter_.[[PrivateForwardingDescriptor]] to _descriptor_.
+    1. Set _setter_.[[PrivateForwardingValueBox]] to _valueBox_.
+    1. Let _getter_ be a new built-in function object as defined in Private Forwarding Getter Functions (<emu-xref href="#sec-private-forwarding-getter-functions"></emu-xref>).
+    1. Set _getter_.[[PrivateForwardingDescriptor]] to _descriptor_.
+    1. Set _getter_.[[PrivateForwardingValueBox]] to _valueBox_.
+    1. Return a new PropertyDescriptor{[[Set]]: _setter_, [[Get]]: _getter_, [[Enumerable]]: *false*, [[Configurable]]: *false*}
+  </emu-alg>
+
+  <emu-clause id="sec-private-forwarding-getter-functions">
+    <h1>Private Forwarding Getter Functions</h1>
+    <p>A private forwarding getter function is an anonymous built-in function that has [[PrivateForwardingDescriptor]] and [[PrivateForwardingValueBox]] internal slots.</p>
+    <p>When a private forwarding getter function _F_ is called, the following steps are taken:</p>
+    <emu-alg>
+      1. Let _valueBox_ be _F_.[[PrivateForwardingValueBox]].
+      1. If _valueBox_.[[Value]] is not ~empty~,
+         1. Return _valueBox_.[[Value]].
+      1. Let _descriptor_ be _F_.[[PrivateForwardingDescriptor]].
+      1. If IsDataDescriptor(_descriptor_) is *true*,
+         1. Assert: _descriptor_.[[Writable]] is *true*.
+         1. Return _descriptor_.[[Value]].
+      1. Assert: _descriptor_.[[Get]] has a [[PrivateForwardingDescriptor]] internal slot.
+      1. Return ! Call(_descriptor_.[[Get]], *undefined*).
+    </emu-alg>
+    <emu-note>Note: The [[Get]] function will always be a Private Forwarding Getter Function, and the receiver will never be used.</emu-note>
+  </emu-clause>
+
+  <emu-clause id="sec-private-forwarding-setter-functions">
+    <h1>Private Forwarding Setter Functions</h1>
+    <p>A private forwarding getter function is an anonymous built-in function that has [[PrivateForwardingDescriptor]] and [[PrivateForwardingValueBox]] internal slots.</p>
+    <p>When a private forwarding getter function _F_ is called with argument _value_, the following steps are taken:</p>
+    <emu-alg>
+      1. Let _valueBox_ be _F_.[[PrivateForwardingValueBox]].
+      1. Set _valueBox_.[[Value]] to _value_.
+      1. Return *undefined*.
+    </emu-alg>
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="sec-copy-private-elements" aoid=CopyPrivateElements>
+  <h1>CopyPrivateElements ( _F_, _constructorProto_ )</h1>
 
   <emu-alg>
     1. For _entry_ in _constructorProto_.[[PrivateFieldDescriptors]],
       1. Let _name_ be _entry_.[[PrivateName]].
       1. Let _descriptor_ be _entry_.[[PrivateFieldDescriptor]].
-      1. If IsAccessorDescriptor(_descriptor_) or _descriptor_.[[Writable]] is *false*,
-        1. Perform ! PrivateFieldDefine(_name_, _F_, _descriptor_).
+      1. If _descriptor_ has a [[Get]] internal slot and _descriptor_.[[Get]] has a [[PrivateForwardingDescriptor]] internal slot, let _stateful_ be *true*.
+      1. Otherwise, if _descriptor_ has a [[Writable]] internal slot, let _stateful_ be _descriptor_.[[Writable]].
+      1. Otherwise, let _stateful_ be *false*.
+      1. If _stateful_ is *true*,
+        1. Set _descriptor_ to PrivateForwardingDescriptor(_descriptor_).
+      1. Perform ! PrivateFieldDefine(_name_, _F_, _descriptor_).
   </emu-alg>
 
-  <emu-note>In this specification, the only elements which will be copied by this algorithm are static private methods and accessors.</emu-note>
+  <emu-note>This algorithm is designed to copy static private fields, methods and accessors. However, if inheriting from an object that has instance fields or methods (for example, a class which had the super return trick applied), those will also be copied/forwarded similarly.</emu-note>
 </emu-clause>
 
   <emu-clause id="static-semantics-is-static">
@@ -164,7 +211,7 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
       1. If _className_ is not *undefined*, then
         1. Perform _classScopeEnvRec_.InitializeBinding(_className_, _F_).
       1. Set the value of _F_'s [[Elements]] internal slot to _elements_.
-      1. <ins>Perform ! CopyImmutablePrivateElements(_F_, _constructorParent_).</ins>
+      1. <ins>Perform ! CopyPrivateElements(_F_, _constructorParent_).</ins>
       1. Perform ? InitializeClassElements(_F_, _proto_).
       1. Return _F_.
     </emu-alg>


### PR DESCRIPTION
With this patch, reads and writes to a static private field which
is inherited from a superclass will behave similarly to reads and
writes to public properties: Reads will forward to the superclass
constructor, and writes will create a new value which is not
forwarded. Thanks to @rbuckton for the idea; this patch is an
iteration of spec drafts by him.

Note that static private fields here are still private, not protected
or public. This patch only affects semantics when their use within
a superclass occurs with a subclass receiver, for example an access
to a private static field from a public static method, which is then called
from a subclass.