### PR TITLE
Normative: Remove lexically scoped functions in classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
-# Static private fields and lexical declarations in classes
+# Static public fields
 
 Champion: Daniel Ehrenberg
 
 Stage 2
 
-This proposal:
-1. **Adds public static fields** as previously proposed. Public static fields are own data properties of the constructor.
-1. **Adds lexical declarations in class bodies**. Lexical declarations are prefixed by a keyword to differentiate them from methods and fields.
-1. **Does not add private static fields and private static methods**. Lexical declarations are intended to fill static private use cases.
+This proposal adds public static fields as previously proposed. Public static fields are own data properties of the constructor. 
 
-This proposal was created to track the "static" (i.e., of the constructor) aspects of the [class fields](http://github.com/tc39/proposal-class-fields) and [private methods](https://github.com/tc39/proposal-private-methods) proposals. In the November 2017 TC39 meeting, the static dimensions of these proposals were demoted to Stage 2, to be broken out into a separate proposal while the instance dimensions remain at Stage 3. Although lexical declarations are significantly different from the previous proposal of static private methods and fields, this feature set is working to accomplish the same use cases, so it is being pursued as part of the same TC39 proposal.
-
-## Static public fields
+## Motivation
 
 Like static public methods, static public fields take a common idiom which was possible to write without class syntax and make it more ergonomic, have more declarative-feeling syntax (although the semantics are quite imperative), and allow free ordering with other class elements.
 
-### Use case
+Declaring static properties in the class body is hoped to be cleaner and doing a better job of meeting programmer expectations of what classes should be for. The latter workaround is a somewhat common idiom, and it would be a nice convenience for programmers if the property declaration could be lifted into the class body, matching how methods are placed there.
+
+## Example
 
 ```js
 class CustomDate {
@@ -33,124 +30,22 @@ class CustomDate {
 CustomDate.epoch = new CustomDate(0);
 ```
 
-Declaring static properties in the class body is hoped to be cleaner and doing a better job of meeting programmer expectations of what classes should be for. The latter workaround is a somewhat common idiom, and it would be a nice convenience for programmers if the property declaration could be lifted into the class body, matching how methods are placed there.
-
-### Semantics
+## Semantics
 
 Define an own property on the constructor which is set to the value of the initializer expression. The initializer is evaluated in a scope where the binding of the class is available--unlike in computed property names, the class can be referred to from inside initializers without leading to a ReferenceError. The `this` value in the initializer is the constructor.
 
-See [ALTERNATIVES.md](https://github.com/tc39/proposal-static-class-features/blob/master/ALTERNATIVES.md#static-fields) for an explanation of some of the edge cases and alternatives considered.
+See [STATICPUBLIC.md](https://github.com/tc39/proposal-static-class-features/blob/master/STATICPUBLIC.md) for an explanation of some of the edge cases and alternatives considered.
 
-## Function scoped declarations in classes
+## Follow-on proposals
 
-This proposal adds lexically scoped `function` declarations (including async functions and generators) in class bodies. To make the syntax intuitively unambiguous, these declarations are prefixed by a yet-to-be-determined keyword. In this explainer, `local` is used in place of a particular token; see [#9](https://github.com/tc39/proposal-static-class-features/issues/9) for discussion of which token should be selected.
-
-### Use case
-
-Based on the example at [#4](https://github.com/tc39/proposal-static-class-features/issues/4) by Domenic Denicola:
-
-```js
-const registry = new JSDOMRegistry();
-export class JSDOM {
-  #createdBy;
-  
-  #registerWithRegistry(registry) {
-    // ... elided ...
-  }
- 
-  static async fromURL(url, options = {}) {
-    url = normalizeFromURLOptions(url, options);
-    
-    const body = await getBodyFromURL(url);
-    return finalizeFactoryCreated(body, options, "fromURL");
-  }
-  
-  static async fromFile(filename, options = {}) {
-    const body = await getBodyFromFilename(filename);
-    return finalizeFactoryCreated(body, options, "fromFile");
-  }
-  
-  local function finalizeFactoryCreated(body, options, factoryName) {
-    normalizeOptions(options);
-    let jsdom = new JSDOM(body, options):
-    jsdom.#createdBy = factoryName;
-    jsdom.#registerWithRegistry(registry);
-    return jsdom;
-  }
-}
-```
-
-### Semantics
-
-Class bodies already contain a lexical scope, in which the class name is bound to the value of the class. In this same lexical scope, this feature adds additional bindings. Function declarations (including async functions, generators and async generators) are hoisted up to the top of the class scope, initialized before the `extends` clause is evaluated. They are defined within this scope, and able to access private instance fields and be accessed by private methods.
-
-### Omitting other lexically declared forms
-
-`let`, `class` and `const` declarations add another time when code observably executes. This execution would need to tie in with [Brian Terlson and Yehuda Katz's broader proposal for class evaluation order](https://github.com/tc39/tc39-notes/blob/master/es7/2016-05/classevalorder.pdf). For the same reason as for static field initializers, it is helpful if the class has an initialized binding when they are executed. Therefore, it would seem logical to execute the statements interspersed with static field initializers (and possibly [element finalizers](https://github.com/tc39/proposal-decorators/issues/42) from decorators), top-to-bottom. Until they evaluate, accessing the variable causes a ReferenceError ("temporal dead zone"). It's unclear, however, how this top-to-bottom initialization order [would be integrated](https://github.com/tc39/proposal-decorators/issues/44) with the decorators proposal.
-
-The scope of these lexical declarations would also be observable in potentially confusing ways. If we use typical lexical scoping rules, it would be the same as the scope of the `extends` clause and computed property names: It is a lexical scope inheriting from outside the class, which includes using `this`, `super`, `await`, `yield` and `arguments`. These features are hidden by function declarations, avoiding the issue. Further discussion is in [#13](https://github.com/tc39/proposal-static-class-features/issues/13).
-
-Finally, the most important use cases that we were able to identify in the development of this proposal were instances of procuedural decomposition. This is typically represented by functions. Although it's possible to write code which would take advantage of the other declarations, it's unclear whether these needs are worth the complexity of the above two issues.
-
-## No static private fields, methods and accessors
-
-Previously, private static fields and methods were proposed. The original proposal for private static fields and methods was that the constructor object where they were defined would have these as private fields, and no other objects would have it. However, Justin Ridgewell, [pointed out](https://github.com/tc39/proposal-class-fields/issues/43) that this would be unexpectedly throw TypeErrors in the case of subclassing.
-
-Lexical declarations enable the known use cases of static private fields and methods. Between the cost in complexity and counter-intuitive semantics and the lack of motivation, this proposal posits that static private features are unlikely to be a justified addition in the future.
-
-See [ALTERNATIVES.md](https://github.com/tc39/proposal-static-class-features/blob/master/ALTERNATIVES.md#static-private) for an in-depth look at various options that were considered to support static private fields and methods.
-
-## Public instance methods remain as previously proposed
-
-Lexical declarations can sometimes be used for situations that would otherwise be used for the Stage 3 [private methods and accessors proposal](https://github.com/tc39/proposal-private-methods). However, the champions do not plan to withdraw the proposal even if lexically scoped function declarations in classes are accepted by TC39 for the following reasons:
-- Private methods provide an easy path to refactoring from public to private--no need to rephrase methods or their callsites, just add a # before the definition and usages.
-- Private methods give access to the right `this` value naturally, without using `Function.prototype.call`, which is core to making the refactoring easy. Many programmers feel comfortable programming JavaScript in an object-oriented style, which private methods support.
-- Private methods support super property access, which is a syntax error in function declarations. It's unclear how lexically scoped declarations could support super property access, as the "home object" would be rather ambiguous--the prototype or the constructor?
-- Private methods are terse and convenient to use, with semantics which is naturally analogous to othre class elements. They should be sufficient for the majority of shared but not exposed behavior in classes.
-- Private methods do not have the TypeError hazards which private static methods have--they are installed in the constructor, so they are present according to the prototype chain of the class hierarchy at the time the instance was constructed.
-
-### Use case
-
-The [private methods explainer](https://github.com/tc39/proposal-private-methods) walks through an example of incrementally refactoring code to make more use of private methods and accessors. The following is the final stage of the code, with the full refactoring in place.
-
-```js
-class Counter extends HTMLElement {
-  #xValue = 0;
-
-  get #x() { return #xValue; }
-  set #x(value) {
-    this.#xValue = value; 
-    window.requestAnimationFrame(this.#render.bind(this));
-  }
-
-  #clicked() {
-    this.#x++;
-  }
-
-  constructor() {
-    super();
-    this.onclick = this.#clicked.bind(this);
-  }
-
-  connectedCallback() { this.#render(); }
-
-  #render() {
-    this.textContent = this.#x.toString();
-  }
-}
-window.customElements.define('num-counter', Counter);
-```
+This proposal is designed to be compatible with several possible follow-on proposals, which are documented at [FOLLOWONS.md](https://github.com/tc39/proposal-static-class-features/blob/master/FOLLOWONS.md).
 
 ## Proposal status
 
-This proposal is at Stage 2. In the November 2017 TC39 meeting, it was [split off](https://github.com/tc39/tc39-notes/blob/master/es8/2017-11/nov-30.md#10iva-continued-inheriting-private-static-class-elements-discussion-and-resolution) from the Stage 3 [class fields](https://github.com/tc39/proposal-class-fields) and [private methods](https://github.com/tc39/proposal-private-methods) proposals--this proposal handles the static aspects, while the other proposals handle instance aspects. This proposal will be presented to TC39 in the January 2018 meeting as an update.
+This proposal is at Stage 2.
+
+This proposal was created to track the "static" (i.e., of the constructor) aspects of the [class fields](http://github.com/tc39/proposal-class-fields) and [private methods](https://github.com/tc39/proposal-private-methods) proposals, namely static public fields, static private fields, and static private methods. In the November 2017 TC39 meeting, the static dimensions of these proposals were demoted to Stage 2, to be broken out into a separate proposal while the instance dimensions remain at Stage 3.
 
 Draft specification text is published at [https://tc39.github.io/proposal-static-class-features/].
 
 Static public fields are implemented in Babel and V8 behind a flag, and had test262 tests written (though currently have been removed due to this proposal being at Stage 2).
-
-Lexical declarations in classes do not currently have any implementations or tests.
-
-Private methods and accessors are [a separate Stage 3 proposal](https://github.com/tc39/proposal-private-methods).
-
-Alternatives to this proposal are considered in [ALTERNATIVES.md](https://github.com/tc39/proposal-static-class-features/blob/master/ALTERNATIVES.md).

--- a/STATICPUBLIC.md
+++ b/STATICPUBLIC.md
@@ -1,0 +1,102 @@
+# Static fields: Why these semantics?
+
+Static public fields are proposed as ordinary data properties of constructors. This document explores the edge cases, implications and some rejected alternative proposals for their semantics.
+
+## Current proposal: Static fields are initialized only once
+
+Kevin Gibbons [raised a concern](https://github.com/tc39/proposal-class-fields/issues/43#issuecomment-340517955) that JavaScript programmers may not be used to having objects with mutated properties which are exposed on the prototype chain, the way that static fields are inherited and may be overwritten. Some reasons why this is not that bad:
+- Many JS classes add a property to a constructor after a class definition. A subclass of Number, for example, would make this issue observable.
+- Lots of current educational materials, e.g., by Kyle Simpson and Eric Elliott, explain directly how prototypical inheritance of data properties in JS works to newer programmers.
+- This proposal is more conservative and going with the grain of JS by not adding a new time when code runs for subclassing, preserving identities as you'd expect, etc.
+
+## Semantics in an edge case with Set and inheritance
+
+Example of how these semantics work out with subclassing (this is not a recommended use of constructors as stateful objects, but it shows the semantic edge cases):
+
+```js
+static Counter {
+  static count = 0;
+  static inc() { this.count++; }
+}
+class SubCounter extends Counter { }
+
+Counter.hasOwnProperty("count");  // true
+SubCounter.hasOwnProperty("count");  // false
+
+Counter.count; // 0, own property
+SubCounter.count; // 0, inherited
+
+Counter.inc();  // undefined
+Counter.count;  // 1, own property
+SubCounter.count;  // 1, inherited
+
+// ++ will read up the prototype chain and write an own property
+SubCounter.inc();
+
+Counter.hasOwnProperty("count");  // true
+SubCounter.hasOwnProperty("count");  // true
+
+Counter.count;  // 1, own property
+SubCounter.count;  // 2, own property
+
+Counter.inc(); Counter.inc();
+Counter.count;  // 3, own property
+SubCounter.count;  // 2, own property
+```
+
+## Why not to reinitialize public fields on subclasses
+
+Kevin Gibbons has proposed that class fields have their initialisers re-run on subclasses. This would address the static private subclassing issue by adding those to subclasses as well, leading to no TypeError on use.
+
+With this alternate, the initial counter example would have the following semantics:
+
+```js
+// NOTE: COUTNERFACTUAL SEMANTICS BELOW
+static Counter {
+  static count = 0;
+  static inc() { this.count++; }
+}
+class SubCounter extends Counter { }
+
+Counter.hasOwnProperty("count");  // true
+SubCounter.hasOwnProperty("count");  // true
+
+Counter.count; // 0, own property
+SubCounter.count; // 0, own property
+
+Counter.inc();  // undefined
+Counter.count;  // 1, own property
+SubCounter.count;  // 0, own property
+
+// ++ is just dealing with own properties the whole time
+SubCounter.inc();
+
+Counter.hasOwnProperty("count");  // true
+SubCounter.hasOwnProperty("count");  // true
+
+Counter.count;  // 1, own property
+SubCounter.count;  // 1, own property
+
+Counter.inc(); Counter.inc();
+Counter.count;  // 3, own property
+SubCounter.count;  // 1, own property
+```
+
+However, these alternate semantics have certain disadvantages:
+- Subclassing in JS has always been "declarative" so far, not actually executing anything from the superclass. It's really not clear this is the kind of hook we want to add to suddenly execute code here.
+- The use cases that have been presented so far for expecting the reinitialization semantics seem to use subclassing as a sort of way to create a new stateful class (e.g., with its own cache or counter, or copy of some other object). These could be accomplished with a factory function which returns a class, without requiring that this is how static fields work in general for cases that are not asking for this behavior.
+
+## Switching all fields to being based on accessors
+
+The idea here is to avoid the subclassing overwriting hazard by changing the semantics of all field declarations: Rather than being own properties that are shadowed by a Set on a subclass, they are accessors (getter/setter pairs). In the case of instance fields, the accessor would read or write on the receiver. In the case of static fields, presumably, the read and write would happen on the superclass where they are defined, ignoring the receiver (otherwise, the TypeError issue from private static fields is then ported to public static fields as well, as the subclass constructor would not have its own value!). Private static fields would also follow this accessor pattern. In all cases, the getter would throw a TypeError when the receiver is an object which does not "have" the private field (e.g., its initializer has not run yet), an effectively new TDZ, which could reduce programmer errors.
+
+Some downsides of this proposal:
+- **Public fields would no longer be own properties**. This may be rather confusing for programmers, who may expect features like object spread to include public instance fields.
+- **Does not help implementations and might hurt startup time (maybe)**. This idea was initially proposed as part of a concept for having 'static shape', which could provide more predictability for implementers and programmers. At least on the implementation side, however, there would either have to be checks on each access to see if the field was initialized, or the initialization state would have to show up in its "hidden class". Either way, there's no efficiency gain if the fields are "already there, just in TDZ". In some implementations, startup time could be even worse than with own properties, until the system learns to optimize out the accessors.
+- **Loses the object model--we'd have to start again**. Data properties have an object model permitting non-writable, non-enumerable and non-configurable properties, including its use by `Object.freeze`. If we want to provide these sorts of capabilities to public fields, they would have to be built again separately.
+
+For these reasons, the public fields proposal has been based on own properties.
+
+## Accessor-like semantics only for static fields
+
+Justin Ridgewell [proposed](https://github.com/tc39/proposal-static-class-features/issues/24) accessor-like semantics for static fields, with own property semantics for instance fields. In addition to the downsides listed in the previous section, this creates a new inconsistency between static and instance, where they are otherwise generally analogous.

--- a/spec.html
+++ b/spec.html
@@ -23,7 +23,6 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
       `static` MethodDefinition[?Yield, ?Await]
       FieldDefinition[?Yield, ?Await] `;`
       <ins>`static` FieldDefinition[?Yield, ?Await] `;`</ins>
-      <ins>`local` HoistableDeclaration[?Yield, ?Await, ~Default]</ins>
       `;`
   </emu-grammar>
 
@@ -55,11 +54,6 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
   <emu-alg>
     1. Return ClassFieldDefinitionEvaluation of |FieldDefinition| with parameter <ins>*false* and</ins> _object_.
   </emu-alg>
-
-  <emu-grammar><ins>ClassElement : `local` HoistableDeclaration</ins></emu-grammar>
-  <ins class="block"><emu-alg>
-    1. Return a new empty List.
-  </emu-alg></ins>
 </emu-clause>
 
 <emu-clause id="runtime-semantics-class-field-definition-evaluation">
@@ -152,10 +146,6 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
-      <emu-grammar>ClassElement : `local` HoistableDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return a new List containing DeclarationPart of |HoistableDeclaration|.
-      </emu-alg>
     </emu-clause>
 
   <emu-clause id="runtime-semantics-class-definition-evaluation">
@@ -203,10 +193,7 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
           1. Let _constructor_ be the result of parsing the source text
             <pre><code class="javascript">constructor( ){ }</code></pre>
             using the syntactic grammar with the goal symbol |MethodDefinition[~Yield]|.
-      1. <ins>Let _classBodyScope_ be new DeclarativeEnvironment(_classScope_).</ins>
-      1. <ins>Let _classBodyScopeEnvRec_ be _classBodyScope_'s EnvironmentRecord.</ins>
-      1. <ins>Perform ! BlockDeclarationInstantiation(|ClassBody|, _classScopeBodyEnvRec_).</ins>
-      1. Set the running execution context's LexicalEnvironment to <del>_classScope_</del><ins>_classBodyScope_</ins>.
+      1. Set the running execution context's LexicalEnvironment to _classScope_.
       1. Set the running execution context's PrivateNameEnvironment to _classPrivateEnvironment_.
       1. Let _constructorInfo_ be the result of performing DefineMethod for _constructor_ with arguments _proto_ and _constructorParent_ as the optional _functionPrototype_ argument.
       1. Assert: _constructorInfo_ is not an abrupt completion.


### PR DESCRIPTION
This PR strips down this proposal repository to be based on a proposition of advancing static public fields separately from other class features, as documented in https://github.com/tc39/proposal-static-class-features/issues/25 . The explainer is modified to split out discussion of possibilities for follow-on proposals into a separate document.