### PR TITLE
Possible typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export class JSDOM {
     return JSDOM.#finalizeFactoryCreated(new JSDOM(body, options), "fromURL");
   }
   
-  static fromFile(filename, options = {}) {
+  async static fromFile(filename, options = {}) {
     normalizeOptions(options);
     
     const body = await getBodyFromFilename(filename);


### PR DESCRIPTION
There's an `await` inside.
Is it really `async static`? `static async` makes more sense.