### PR TITLE
Normative: Prohibit mismatched getter/setter pairs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29,6 +29,13 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
 
   <emu-clause id="sec-static-semantics-early-errors">
     <h1>Static Semantics: Early Errors</h1>
+    <emu-grammar>
+      ClassBody : ClassElementList
+    </emu-grammar>
+    <ul>
+      <li>It is a Syntax Error if PrivateBoundNames of |ClassBody| contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries<ins>, and the getter and setter are either both static or both non-static</ins>.</li>
+    </ul>
+
     <emu-grammar><ins>ClassElement : `static` FieldDefinition `;`</ins></emu-grammar>
     <ul>
       <li>
@@ -45,7 +52,6 @@ contributors: Daniel Ehrenberg, Jeff Morrison, Kevin Smith, Kevin Gibbons
 
     <emu-note type="editor">Removing this early error enables static private methods.</emu-note>
   </emu-clause>
-
 </emu-clause>
 
 <emu-clause id=sec-algorithms>


### PR DESCRIPTION
It must be an early error to have a static private getter and
non-static private setter, or vice versa, for the same private name.
This PR creates that early error.

Closes #48